### PR TITLE
fix development mode and add terraform support

### DIFF
--- a/foldr-uk-website/blog/2021-04-10-terraform-rotate-secrets.md
+++ b/foldr-uk-website/blog/2021-04-10-terraform-rotate-secrets.md
@@ -39,7 +39,7 @@ And the `even` password rotates at the beginning of the even months and is the c
 
 And now for the terraform:
 
-```terraform
+```hcl
 variable "date" {
     type = string
 }

--- a/foldr-uk-website/blog/2021-04-18-bootstrap-azure-terraform-state.md
+++ b/foldr-uk-website/blog/2021-04-18-bootstrap-azure-terraform-state.md
@@ -20,7 +20,7 @@ This stores your state in an Azure Storage Account. The following Terraform will
 
 `main.tf`
 
-```terraform
+```hcl
 resource "azurerm_resource_group" "terraform_state" {
   name     = var.resource_group_name
   location = var.location
@@ -51,7 +51,7 @@ To run it, you'll need to supply a file with the following variables set:
 
 `bootstrap.tfvars`
 
-```
+```hcl
 # the name of the resource group
 # e.g. "rg-mytfstate-shared-001"
 resource_group_name = ""

--- a/foldr-uk-website/blog/2021-04-19-microsoft-graph-terraform-data-source.md
+++ b/foldr-uk-website/blog/2021-04-19-microsoft-graph-terraform-data-source.md
@@ -15,7 +15,7 @@ to do code reviews where reviewers typically just believe the comment that descr
 This is what the code for the required_resource_access for an azure ad application for k8s looks like using just the GUIDs 
 (this is from a real example online):
 
-```terraform
+```hcl
 required_resource_access {
   resource_app_id = "00000003-0000-0000-c000-000000000000"
   resource_access {
@@ -40,7 +40,7 @@ the Microsoft Graph.
 
 You can look this up as a data source using Terraform as follows:
 
-```terraform
+```hcl
 data "azuread_service_principal" "graph" {
     # graph api application id
     application_id = "00000003-0000-0000-c000-000000000000"
@@ -50,7 +50,7 @@ data "azuread_service_principal" "graph" {
 This will return a data source that has all of the oauth2 permissions and app roles for the Microsoft Graph. They can be awkward to
 work with, so I'll usually create a new object that maps the permission name to the permission id e.g.:
 
-```terraform
+```hcl
 locals {
     graph = {
         application_id = data.azuread_service_principal.graph.application_id
@@ -62,7 +62,7 @@ locals {
 
 Using this, the example above would look like:
 
-```terraform
+```hcl
 required_resource_access {
   resource_app_id = local.graph.application_id
   resource_access {

--- a/foldr-uk-website/docusaurus.config.js
+++ b/foldr-uk-website/docusaurus.config.js
@@ -56,6 +56,9 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} Jamie McCrindle. Built with Docusaurus.`,
     },
+    prism: {
+      additionalLanguages: ['powershell', 'csharp', 'hcl'],
+    },
   },
   presets: [
     [
@@ -63,6 +66,15 @@ module.exports = {
       {
         docs: false,
         blog: {
+          blogTitle: 'Jamie McCrindle',
+          blogDescription: 'A programming blog',
+          /**
+           * Number of blog post elements to show in the blog sidebar
+           * 'ALL' to show all blog posts
+           * 0 to disable
+           */
+          blogSidebarCount: 5,
+          postsPerPage: 1, // if not specified then http://localhost:3000/ will be an empty screen
           path: "./blog",
           routeBasePath: "/", // Set this value to '/'.
           showReadingTime: true,


### PR DESCRIPTION
This PR does three things: fixes development mode and adds language support for Terraform (two parts to this).

### Development mode

Running locally without `postsPerPage` being specified in your config you get a blank screen when you go to http://localhost:3000

This specifies that config (and a couple of other properties) which resolves the blank screen issue.

### Language support

You need to specify the languages that you're using if they're outside the list of commonly used languages: https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js

This PR adds support for CSharp, PowerShell (which you're not using yet but it seems plausible) and Terraform (which you are)

### `terraform` -> `hcl`

Confusingly, Terraform is coded as `hcl`.  This PR migrates to use that code.

https://github.com/PrismJS/prism/issues/1252
https://github.com/PrismJS/prism/pull/1594